### PR TITLE
Switch usage of .toISOString() to getting local date

### DIFF
--- a/companion/index.js
+++ b/companion/index.js
@@ -3,7 +3,8 @@ import { settingsStorage } from "settings";
 
 // Fetch Sleep Data from Fitbit Web API
 function fetchSleepData(accessToken)  {
-  let todayDate = new Date().toISOString().slice(0,10); //YYYY-MM-DD
+  let date = new Date();
+  let todayDate = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`; //YYYY-MM-DD
 
   // Sleep API docs - https://dev.fitbit.com/reference/web-api/sleep/
   fetch(`https://api.fitbit.com/1.2/user/-/sleep/date/${todayDate}.json`, {


### PR DESCRIPTION
.toISOString() returns the time in UTC. This is isn't good for folks in other timezones. This change gets the local time and grabs only the date in local time.